### PR TITLE
Encapsulate request message construction and ops generation logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,14 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-          
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true  
-      
+
       - name: Build dockerfile
         run: docker build -t cjen1/rc:latest .
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ env
 systems/zookeeper/clients/java/Client.jar
 
 **/.merlin
+.vscode

--- a/scripts/test_entrypoint.sh
+++ b/scripts/test_entrypoint.sh
@@ -4,7 +4,7 @@ service openvswitch-switch start
 ovs-vsctl set-manager ptcp:6640
 
 python benchmark.py etcd_go \
-  simple --topo_args n=1,nc=1 uniform --dist_args write_ratio=1 none \
+  simple --topo_args n=1,nc=1 uniform --write_ratio 1 none \
   --benchmark_config rate=1000,duration=10,dest=./res,logs=./logs `realpath .`
 
 service openvswitch-switch stop

--- a/scripts/test_entrypoint.sh
+++ b/scripts/test_entrypoint.sh
@@ -4,7 +4,7 @@ service openvswitch-switch start
 ovs-vsctl set-manager ptcp:6640
 
 python benchmark.py etcd_go \
-  simple --topo_args n=1,nc=1 uniform --write_ratio 1 none \
+  simple --topo_args n=1,nc=1 uniform --write-ratio 1 none \
   --benchmark_config rate=1000,duration=10,dest=./res,logs=./logs `realpath .`
 
 service openvswitch-switch stop

--- a/src/distributions/__init__.py
+++ b/src/distributions/__init__.py
@@ -1,0 +1,54 @@
+from enum import Enum
+from src.distributions.uniform import UniformOpsProvider
+
+
+class DistributionType(Enum):
+    Uniform = 'uniform'
+
+    def __str__(self):
+        return self.value
+
+
+def _parse_key_range_arg(key_range_raw):
+    krl, kru = key_range_raw.split('>')
+    return int(krl), int(kru)
+
+
+def register_ops_args(parser):
+    dist_group = parser.add_argument_group('distribution')
+
+    dist_group.add_argument(
+        'dist_type', type=DistributionType,
+        choices=list(DistributionType))
+
+    dist_group.add_argument(
+        '--write-ratio',
+        type=float,
+        default=0.5,
+        help='percentage of client\'s write operation, defaults to %(default)s')
+
+    dist_group.add_argument(
+        '--payload-size',
+        type=int,
+        default=10,
+        help='upper bound of write operation\'s payload size in bytes, defaults to %(default)s')
+
+    dist_group.add_argument(
+        '--key-range',
+        type=_parse_key_range_arg,
+        default='1>10',
+        help="'>' separated lower and (inclusive) upper bound of keys, defaults to %(default)s")
+
+
+def get_ops_provider(args):
+    if args.dist_type is DistributionType.Uniform:
+        return UniformOpsProvider(
+            key_range_lower=args.key_range[0],
+            key_range_upper=args.key_range[1],
+            payload_size=args.payload_size,
+            write_ratio=args.write_ratio,
+        )
+    else:
+        raise Exception(
+            'Not supported distribution type: ' + args.dist_type
+        )

--- a/src/utils/req_factory.py
+++ b/src/utils/req_factory.py
@@ -1,0 +1,32 @@
+import src.utils.message_pb2 as Msg
+
+
+class ReqFactory(object):
+    @staticmethod
+    def finalise():
+        finalise = Msg.Request()
+        finalise.finalise.msg = ""
+        return finalise
+
+    @staticmethod
+    def start():
+        start = Msg.Request()
+        start.start.msg = ""
+        return start
+
+    @staticmethod
+    def write(key, value, start, prereq=False):
+        putOp = Msg.Request()
+        putOp.op.put.key = key
+        putOp.op.put.value = value
+        putOp.op.start = start
+        putOp.op.prereq = prereq
+        return putOp
+
+    @staticmethod
+    def read(key, start, prereq=False):
+        getOp = Msg.Request()
+        getOp.op.get.key = key
+        getOp.op.start = start
+        getOp.op.prereq = prereq
+        return getOp


### PR DESCRIPTION
### About this PR:
- Added `ReqFactory` so that other parts of the framework wouldn't need to work about the details of message construction
- Put the logic for uniform ops generation into `UniformOpsProvider` class
- In `distribution.__init__.py`:
  - added an enum to represent types of distributions `DistributionType `
  - added a factory method to dispatch ops provider construction, based on `DistributionType` given
  - registered distribution related cli arguments under the same argument group `distribution`, `python benchmark.py --help` now has this snippet:
```
distribution:
  {uniform}
  --write-ratio WRITE_RATIO
                        percentage of client's write operation, defaults to
                        0.5
  --payload-size PAYLOAD_SIZE
                        upper bound of write operation's payload size in
                        bytes, defaults to 10
  --key-range KEY_RANGE
                        '>' separated lower and (inclusive) upper bound of
                        keys, defaults to 1>10
```

### Testing:
- tested by running the github action cmd locally